### PR TITLE
[Harvesting multi-pages with auth] Removing credentials on import

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -10,6 +10,9 @@ export const TASK_TYPE = 'http://redpencil.data.gift/vocabularies/tasks/Task';
 export const ERROR_TYPE= 'http://open-services.net/ns/core#Error';
 export const ERROR_URI_PREFIX = 'http://redpencil.data.gift/id/jobs/error/';
 
+export const BASIC_AUTH = 'https://www.w3.org/2019/wot/security#BasicSecurityScheme';
+export const OAUTH2 = 'https://www.w3.org/2019/wot/security#OAuth2SecurityScheme';
+
 export const PREFIXES = `
   PREFIX harvesting: <http://lblod.data.gift/vocabularies/harvesting/>
   PREFIX terms: <http://purl.org/dc/terms/>
@@ -17,9 +20,16 @@ export const PREFIXES = `
   PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+  PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
   PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX oslc: <http://open-services.net/ns/core#>
   PREFIX cogs: <http://vocab.deri.ie/cogs#>
   PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
+  PREFIX dgftOauth: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
+  PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
+  PREFIX rpioHttp: <http://redpencil.data.gift/vocabularies/http/>
+  PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
 `;

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -1,0 +1,100 @@
+import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri } from "mu";
+import { BASIC_AUTH, OAUTH2, PREFIXES } from "../constants";
+
+
+/**
+ * Gets CredentialsType from RemoteDataObject
+ * @param {String} remoteDataObjectUri
+ * @returns credentialsType
+ */
+
+async function getCredentialsTypeForRemoteDataObject(remoteDataObjectUri) {
+  const credentialsTypeQuery = `
+    PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+    SELECT DISTINCT ?securityConfigurationType WHERE {
+        ${sparqlEscapeUri(
+          remoteDataObjectUri
+        )} dgftSec:targetAuthenticationConfiguration ?authenticationConf .
+        ?authenticationConf dgftSec:securityConfiguration/rdf:type ?securityConfigurationType .
+        VALUES ?securityConfigurationType {
+          <https://www.w3.org/2019/wot/security#BasicSecurityScheme>
+          <https://www.w3.org/2019/wot/security#OAuth2SecurityScheme>
+      }
+    }
+  `;
+  const credentialsType = await query(credentialsTypeQuery);
+  return credentialsType.results.bindings[0]
+    ? credentialsType.results.bindings[0].securityConfigurationType.value
+    : null;
+}
+
+/**
+ * Deletes credentials from remoteDataObject.
+ * @param {String} remoteDataObjectUri
+ */
+
+export async function deleteCredentials(remoteDataObjectUri) {
+  let credentialsType;
+  let cleanOauth2Query = `
+      ${PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets dgftOauth:clientId ?clientId ;
+            dgftOauth:clientSecret ?clientSecret .
+        }
+      } WHERE {
+      
+        ${sparqlEscapeUri(
+          remoteDataObjectUri
+        )} dgftSec:targetAuthenticationConfiguration ?configuration .
+      
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets dgftOauth:clientId ?clientId ;
+            dgftOauth:clientSecret ?clientSecret .
+        }
+      }
+      `;
+  let cleanBasicAuthQuery = `
+      ${PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets meb:username ?user ;
+            muAccount:password ?pass .
+        }
+      } WHERE {
+      
+        ${sparqlEscapeUri(
+          remoteDataObjectUri
+        )} dgftSec:targetAuthenticationConfiguration ?configuration .
+      
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets meb:username ?user ;
+            muAccount:password ?pass .
+        }
+      }
+      `;
+
+  if (!credentialsType)
+    credentialsType = await getCredentialsTypeForRemoteDataObject(
+      remoteDataObjectUri
+    );
+
+  switch (credentialsType) {
+    case BASIC_AUTH:
+      await update(cleanBasicAuthQuery);
+      break;
+    case OAUTH2:
+      await update(cleanOauth2Query);
+      break;
+    default:
+      return false;
+  }
+}

--- a/lib/pipeline-import.js
+++ b/lib/pipeline-import.js
@@ -14,6 +14,7 @@ import { loadTask, isTask, updateTaskStatus, appendTaskError } from './task';
 
 import validateTriple from './validateTriple';
 import fixTriple from './fixTriple';
+import { deleteCredentials } from './credential-helpers';
 
 export async function run(deltaEntry) {
   const task = await loadTask(deltaEntry);
@@ -79,6 +80,9 @@ async function constructExtractor(pages) {
   for (let page of pages) {
     const html = await getFileContent(page);
     const metaData = await getFileMetadata(page);
+    // TODO: still need find a better place for this
+    // page here is the remoteDataObject so we delete the credentials from it
+    await deleteCredentials(page);
     await extractor.addPage(html, metaData);
   }
   return extractor;


### PR DESCRIPTION
DL-4860

This PR is responsible of making the harvesting for multiple pages with authentication working.

This is linked to other PRs in `harvest-collector-service` : https://github.com/lblod/harvest-collector-service/pull/13 and `download-url-service` : https://github.com/lblod/download-url-service/pull/12, so to test it make sure you have them in your docker override file.

Note : The deleteCredentials method needs to be located elsewhere.