### PR TITLE
handle int datatype

### DIFF
--- a/lib/fixTriple.js
+++ b/lib/fixTriple.js
@@ -1,6 +1,5 @@
-const N3 = require('n3');
 import { validateTerm } from './validateTriple';
-
+import { Parser, Writer, DataFactory } from 'n3';
 /**
  * Returns a promise that resolved to a string representation of a triple
  * if it could be fixed or to undefined if it couldn't
@@ -9,7 +8,7 @@ import { validateTerm } from './validateTriple';
  */
 export default function fixTriple(triple) {
   return new Promise((resolve) => {
-    const parser = new N3.Parser();
+    const parser = new Parser();
     parser.parse(triple, (error, quad) => {
       if (error) {
         console.log(error);
@@ -33,7 +32,7 @@ export default function fixTriple(triple) {
         const object = fixTerm(quad.object);
         if (!object) return resolve(undefined);
 
-        const writer = new N3.Writer();
+        const writer = new Writer();
         writer.addQuad(subject, predicate, object);
         writer.end((err, result) => {
           if (err) {
@@ -85,7 +84,7 @@ function fixTerm(term) {
 function fixBoolean(term) {
   const lowercaseValue = term.value.toLowerCase();
   if (lowercaseValue === 'true' || lowercaseValue === 'false') {
-    return N3.DataFactory.literal(lowercaseValue, N3.DataFactory.literal('http://www.w3.org/2001/XMLSchema#boolean'));
+    return DataFactory.literal(lowercaseValue, DataFactory.literal('http://www.w3.org/2001/XMLSchema#boolean'));
   } else {
     return undefined;
   }
@@ -105,7 +104,7 @@ function fixDate(term) {
     const month = date.getMonth() < 9 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
     const day = date.getDate();
     const newValue = `${year}-${month}-${day}`;
-    return N3.DataFactory.literal(newValue, N3.DataFactory.literal('http://www.w3.org/2001/XMLSchema#date'));
+    return DataFactory.literal(newValue, DataFactory.literal('http://www.w3.org/2001/XMLSchema#date'));
   }
 }
 
@@ -120,7 +119,7 @@ function isValidDate(date) {
 
 function fixLiteral(term) {
   const value = term.value;
-  return N3.DataFactory.literal(value, N3.DataFactory.literal('http://www.w3.org/2001/XMLSchema#string'));
+  return DataFactory.literal(value, DataFactory.literal('http://www.w3.org/2001/XMLSchema#string'));
 }
 
 /**
@@ -140,6 +139,6 @@ function fixDateTime(term) {
     const minute = date.getMinutes();
     const seconds = date.getSeconds();
     const newValue = `${year}-${month}-${day}T${hour}:${minute}:${seconds}`;
-    return N3.DataFactory.literal(newValue, N3.DataFactory.literal('http://www.w3.org/2001/XMLSchema#dateTime'));
+    return DataFactory.literal(newValue, DataFactory.literal('http://www.w3.org/2001/XMLSchema#dateTime'));
   }
 }

--- a/lib/fixTriple.js
+++ b/lib/fixTriple.js
@@ -69,6 +69,8 @@ function fixTerm(term) {
         return fixLiteral(term);
       } else if (term.datatype.value == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString') {
         return fixLiteral(term);
+      } else if (term.datatype.value === 'http://www.w3.org/2001/XMLSchema#int') {
+        return fixInteger(term);
       }
     }
     return undefined;
@@ -117,6 +119,13 @@ function isValidDate(date) {
   return date instanceof Date && !isNaN(date);
 }
 
+function fixInteger(term) {
+  if (isNaN(Number(term.value))) {
+    return undefined;
+  } else {
+    return DataFactory.literal(term.value, DataFactory.literal('http://www.w3.org/2001/XMLSchema#integer'));
+  }
+}
 function fixLiteral(term) {
   const value = term.value;
   return DataFactory.literal(value, DataFactory.literal('http://www.w3.org/2001/XMLSchema#string'));


### PR DESCRIPTION
`xsd:int` is not the same as `xsd:integer`, but in this case we can pretty safely just replace them and be compliant with the model. Other option would be to allow both `xsd:int` and `xsd:integer` where the shacl currently requires `xsd:integer`, but I'm unsure if this would not have side effects in virtuoso or other services.