### PR TITLE
Bump rdf-serializer

### DIFF
--- a/lib/rdfa-extractor.js
+++ b/lib/rdfa-extractor.js
@@ -2,7 +2,7 @@ import streamToArray from "stream-to-array";
 import { JSDOM } from "jsdom";
 import getRDFaGraph from "@lblod/graph-rdfa-processor";
 import { createUnzip } from "zlib";
-import rdfSerializer from "rdf-serialize";
+import { rdfSerializer } from "rdf-serialize";
 import { createReadStream } from "fs";
 import { DataFactory, Store, StreamParser } from "n3";
 const { namedNode, quad } = DataFactory;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash.uniq": "^4.5.0",
     "lodash.uniqwith": "^4.5.0",
     "n3": "^1.17.0",
-    "rdf-serialize": "^2.2.2",
+    "rdf-serialize": "^3.0.0",
     "stream-to-array": "^2.3.0",
     "stream-to-string": "^1.2.0",
     "streamify-array": "^1.0.1",


### PR DESCRIPTION
Bumped and corrected the use of the `rdf-serializer`. This was needed to fix the error I would constantly get:

```
Class constructor ActionContext cannot be invoked without 'new' in the serializer code.
```

The above error happened on every Task I gave it.

Seems like the developer of `rdf-serialize` was aware of the issue and got it fixed in the next major release.